### PR TITLE
fix: stop gitignoring weekly_report/reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Ignore sample data JSON files
 fpl/sample_data/*.json
 
-# Generated weekly reports (local dev output)
-weekly_report/reports/
-
 # FPL API response cache
 .fpl_cache/
 # Byte-compiled / optimized / DLL files

--- a/TODO_REFACTOR_QualityCleanup.md
+++ b/TODO_REFACTOR_QualityCleanup.md
@@ -78,6 +78,12 @@ All three files are 100% complete:
 - [ ] `.github/workflows/scheduled-build.yml` updated to use `python-version: '3.13'` (instead of `'3.x'`)
 - [ ] Both workflows are valid YAML (no syntax errors)
 
+**Task 2**
+Ruff complaint: N801 Class name `FPL_API` should use CapWords convention. Refactor the class name to the CapWords convention.
+
+**Acceptance Criteria**:
+- [ ] Ruff warning about class name `FPL_API` disappears.
+
 ---
 
 ### Job 4: Fix nightly build to generate all output types

--- a/generate_weekly_report.py
+++ b/generate_weekly_report.py
@@ -184,6 +184,8 @@ def main() -> None:
                 / season
                 / f"gw{event_id}.md"
             )
+            assert report_path is not None
+            assert narrative_path_expected is not None
             report_exists = report_path.is_file()
             narrative_exists = narrative_path_expected.is_file()
 

--- a/weekly_report/NARRATIVE_GUIDE.md
+++ b/weekly_report/NARRATIVE_GUIDE.md
@@ -217,11 +217,27 @@ FPL-specific English terms are commonly used in Norwegian FPL culture and should
 
 - Output as **markdown**
 - Use a clear title: `# Reidars Rapport — Runde {N}`
-- Use `##` subheadings sparingly — only when there's a natural section break
-- Paragraphs over bullet points — this is a column, not a report
-- Bold (`**`) for emphasis on key stats or names, but don't overuse
+- Always include one of Reidar's column images right after the title. For instance: `![Reidars Rapport](../../reidars_rapport_2.png)`
 - No emojis — Reidar's humor is in the words, not the decoration
 - No tables or structured data — the narrative should read as prose
+
+### Visual Structure
+
+The column should be easy to scan. Think newspaper layout — a reader should be able to skim the subheadings and get the shape of the round, then dive into the paragraphs for the texture. Walls of text are the enemy.
+
+- **Subheadings (`##`)**: Use 3–5 per column to break the text into clear sections. They should be short, punchy, and opinionated — not generic labels. Good: `## Bench boost. Fem poeng.` or `## Hauk og benken fra helvete`. Bad: `## Rundevinneren` or `## Oppsummering`. The subheading is Reidar's first comment on the section — it sets the tone before the reader even starts.
+- **Bold (`**`)** for emphasis: Key stats, scores, and player names that carry the sentence. Use it to create visual anchors — a reader scanning the text should catch the important numbers. "Palmer som kaptein ga **6 poeng**" pulls the eye. But don't bold entire sentences. One or two bold phrases per paragraph maximum.
+- **Short standalone lines**: A single punchy sentence on its own line, separated by blank lines, creates a dramatic pause. Use for landing punchlines, reactions, or stats that speak for themselves:
+
+  ```
+  97 poeng.
+
+  FK Nabansen leverer den høyeste enkeltrundescore i ligaens historie.
+  ```
+
+  This is Reidar's equivalent of the raised eyebrow. Don't overuse it — two or three times per column maximum, or it loses its punch.
+- **Paragraph rhythm**: Vary paragraph length. A long analytical paragraph followed by a two-sentence paragraph followed by a standalone line creates visual rhythm. Three long paragraphs in a row is a wall. Three short ones in a row feels choppy. Mix them.
+- **Paragraphs over bullet points**: This is a column, not a report. Never use bullet lists in the narrative.
 
 ### Tone Calibration
 

--- a/weekly_report/narratives/1638989/2025-26/gw27.md
+++ b/weekly_report/narratives/1638989/2025-26/gw27.md
@@ -1,0 +1,33 @@
+# Reidars Rapport — Runde 27
+
+Så. Her er vi.
+
+Reidar Fjellvik, ny spaltist for Sinkaberg administrasjon-ligaen. Eller, som resten av verden kjenner den: en miniliga med åtte managere, varierende grad av kompetanse, og et poenggap fra topp til bunn som tyder på at ikke alle tar dette like seriøst. Reidar har dekket FPL-ligaer i mange år. For mange, vil noen si. Han sier det selv, faktisk, men han er fortsatt her. Noen må holde oversikt. Noen må stille spørsmålene ingen andre gidder å stille — som hvorfor man spiller bench boost i runde 27 når benken leverer fem poeng. Men vi kommer til det.
+
+Åtte managere. Anders på topp med 1567 poeng, Peder på bunn med 1296. Elleve runder igjen. Reidar har lest seg opp, studert tallene, og dannet seg et førsteinntrykk av hver enkelt. Noen av disse inntrykkene er sjenerøse. De fleste er det ikke. La oss begynne.
+
+52 poeng vinner runden. Femtito. Reidar har skrevet det tallet, stirret på det, og bestemt seg for å ikke skrive noe mer om det enn nødvendig. Det var den typen runde der man sjekker poengsummen, legger fra seg telefonen, og later som ingenting skjedde. Snittet i ligaen var 42.5. Det er ikke et snitt. Det er en kollektiv kapitulasjon.
+
+Anders og Thisistheyear tar rundepremien med 52, hjulpet av en Nico O'Reilly som ingen visste hvem var for tre uker siden og som plutselig leverer 17 poeng fra ingensteds. Resten av laget? Raya med 3, Gabriel med 2, Timber med 3, Palmer som kaptein med sørgelige 6. Det var O'Reilly-showet, og Anders var heldig nok til å ha billett. Greit nok. Det er alt Reidar har å si om det.
+
+Men så. Torkil. FK Haralds/By. Bench boost.
+
+Reidar må ta en pause her. Torkil spilte bench boost — FPLs mest verdifulle chip etter free hit, et våpen man sparer til doble gameweeks og stappfulle runder — i en runde der benken hans leverte tilnærmet ingenting. Wirtz fikk null. Alderete fikk 1. Dúbravka og Mané delte 4 poeng mellom seg. Totalt hentet FK Haralds/By omtrent 5 ekstra poeng fra bench boost. Fem. Det er ikke et chiputbytte. Det er en begravelse. Torkil endte på 52, samme som Anders, men med en chip mindre i lomma og ingenting å vise for det. Haaland som kaptein ga 12, og Muñoz leverte 9, men det hjelper lite når hensikten med runden var å hente verdi fra en benk som nektet å samarbeide. Reidar har sett bench boost-katastrofer før. Dette er ikke den verste. Men den er oppe og nikker.
+
+Og så har vi Hauk. Sisteplass læll. 31 poeng. Og 23 av dem på benken.
+
+Tjuetre poeng. Van Hecke med 9, Wilson med 8, Dewsbury-Hall med 4, Dúbravka med 2. Alle på benken. Alle ubrukte. Hauk scoret 31 med startelleveren sin og hadde nok poeng på benken til å vinne runden om de hadde spilt. Morgan Rogers som kaptein ga 4 poeng — to base ganger to — i en runde der João Pedro og Haaland lå der for plukking. Det er den typen uke som får folk til å google «hvordan slette FPL-lag». Reidar vet. Han har googlet det selv. Man finner ikke svaret.
+
+Odas Disipler lander på 37. Summerville som kaptein ga 6, og Stach med sine 11 poeng råtner på benken — det er 11 poeng Oda aldri får tilbake. Oda holder tredjeplassen, men marginene ned til Hedda er tynnere enn de ser ut.
+
+Hedda og Tafatt IL fikk 41. João Pedro som kaptein var rundens lureste valg — 14 kapteinspoeng, best i ligaen. Men resten av laget motarbeidet henne. Pickford med 1, Mukiele med 1, Stach med 11 på benken etter å ha blitt hentet inn denne uken. Tre bytter, alle med positiv uttelling på papiret, men det hjelper lite når halvparten av startoppstillingen leverer ettall.
+
+Camilla spilte wildcard og YVIL scorer 50. Seks bytter inn, João Pedro som kaptein med 14 poeng — samme som Hedda, og samme logikk. James Hill leverte 6 fra forsvaret, og det nye laget ser... vel, det ser ut som et lag. Om det er et *godt* lag gjenstår å se. Wildcard-effekten måles ikke i én runde. Den måles i de neste fem. Camilla klatrer forbi Eirin til sjetteplass, men avstanden er 5 poeng. Det er ingenting.
+
+Eirin og Dragen BK synker til sjuendeplass med 34. Gabriel som kaptein — en forsvarsspiller — ga 4 poeng. Reidar har meninger om å sette kapteinsbåndet på en forsvarsspiller i en runde der Haaland og Palmer er tilgjengelige, men han holder dem for seg selv. Stort sett. Bart Verbruggen på benken med 7 poeng mens Raya startet med 3 er salt i såret. Noen ganger velger man feil keeper. De fleste ganger velger man feil keeper.
+
+Peder og Team Eiden med venna scorer 43 og holder sisteplassen trygt. Van Dijk med 11 og Dunk med 6 bar laget fra forsvarsfireren, mens Ekitiké som kaptein ga 4. Avstanden opp til Eirin er 104 poeng. Det er ikke et gap. Det er en avgrunn. Men Peder har vist før at han kan levere når det gjelder minst. Spørsmålet er om det noen gang gjelder nok.
+
+I sammendraget er det bunnfryst. Ingen byttet plass bortsett fra Camilla og Eirin. Anders leder med 35 poengs margin ned til Torkil, og 271 ned til Peder. Det er fortsatt elleve runder igjen. Reidar sier ikke at det er over. Men han sier heller ikke at det ikke er det.
+
+Neste deadline nærmer seg. Torkil har brukt bench boost. Hauk burde vurdere å bruke noe som helst. Og Reidar skal skrive en ny kolonne. Som alltid.

--- a/weekly_report/narratives/1638989/2025-26/gw27.md
+++ b/weekly_report/narratives/1638989/2025-26/gw27.md
@@ -1,33 +1,57 @@
 # Reidars Rapport — Runde 27
 
+![Reidars Rapport](../../reidars_rapport_2.png)
+
 Så. Her er vi.
 
-Reidar Fjellvik, ny spaltist for Sinkaberg administrasjon-ligaen. Eller, som resten av verden kjenner den: en miniliga med åtte managere, varierende grad av kompetanse, og et poenggap fra topp til bunn som tyder på at ikke alle tar dette like seriøst. Reidar har dekket FPL-ligaer i mange år. For mange, vil noen si. Han sier det selv, faktisk, men han er fortsatt her. Noen må holde oversikt. Noen må stille spørsmålene ingen andre gidder å stille — som hvorfor man spiller bench boost i runde 27 når benken leverer fem poeng. Men vi kommer til det.
+Reidar Fjellvik, ny spaltist for Sinkaberg administrasjon-ligaen. Eller, som resten av verden kjenner den: en miniliga med åtte managere, varierende grad av kompetanse, og et poenggap fra topp til bunn som tyder på at ikke alle tar dette like seriøst. Reidar har dekket FPL-ligaer i mange år. For mange, vil noen si. Han sier det selv, faktisk, men han er fortsatt her. Noen må holde oversikt. Noen må stille spørsmålene ingen andre gidder å stille — som hvorfor man spiller bench boost i runde 27 når benken leverer fem poeng.
 
-Åtte managere. Anders på topp med 1567 poeng, Peder på bunn med 1296. Elleve runder igjen. Reidar har lest seg opp, studert tallene, og dannet seg et førsteinntrykk av hver enkelt. Noen av disse inntrykkene er sjenerøse. De fleste er det ikke. La oss begynne.
+Men vi kommer til det.
 
-52 poeng vinner runden. Femtito. Reidar har skrevet det tallet, stirret på det, og bestemt seg for å ikke skrive noe mer om det enn nødvendig. Det var den typen runde der man sjekker poengsummen, legger fra seg telefonen, og later som ingenting skjedde. Snittet i ligaen var 42.5. Det er ikke et snitt. Det er en kollektiv kapitulasjon.
+Åtte managere. Anders på topp med **1567 poeng**, Peder på bunn med **1296**. Elleve runder igjen. Reidar har lest seg opp, studert tallene, og dannet seg et førsteinntrykk av hver enkelt. Noen av disse inntrykkene er sjenerøse. De fleste er det ikke.
 
-Anders og Thisistheyear tar rundepremien med 52, hjulpet av en Nico O'Reilly som ingen visste hvem var for tre uker siden og som plutselig leverer 17 poeng fra ingensteds. Resten av laget? Raya med 3, Gabriel med 2, Timber med 3, Palmer som kaptein med sørgelige 6. Det var O'Reilly-showet, og Anders var heldig nok til å ha billett. Greit nok. Det er alt Reidar har å si om det.
+## 52 poeng vinner runden. Femtito.
 
-Men så. Torkil. FK Haralds/By. Bench boost.
+Det var den typen runde der man sjekker poengsummen, legger fra seg telefonen, og later som ingenting skjedde. Snittet i ligaen var **42.5**. Det er ikke et snitt. Det er en kollektiv kapitulasjon.
 
-Reidar må ta en pause her. Torkil spilte bench boost — FPLs mest verdifulle chip etter free hit, et våpen man sparer til doble gameweeks og stappfulle runder — i en runde der benken hans leverte tilnærmet ingenting. Wirtz fikk null. Alderete fikk 1. Dúbravka og Mané delte 4 poeng mellom seg. Totalt hentet FK Haralds/By omtrent 5 ekstra poeng fra bench boost. Fem. Det er ikke et chiputbytte. Det er en begravelse. Torkil endte på 52, samme som Anders, men med en chip mindre i lomma og ingenting å vise for det. Haaland som kaptein ga 12, og Muñoz leverte 9, men det hjelper lite når hensikten med runden var å hente verdi fra en benk som nektet å samarbeide. Reidar har sett bench boost-katastrofer før. Dette er ikke den verste. Men den er oppe og nikker.
+Anders og Thisistheyear tar rundepremien, hjulpet av en Nico O'Reilly som ingen visste hvem var for tre uker siden og som plutselig leverer **17 poeng** fra ingensteds. Resten av laget? Raya med 3, Gabriel med 2, Timber med 3, Palmer som kaptein med sørgelige **6**. Det var O'Reilly-showet, og Anders var heldig nok til å ha billett.
 
-Og så har vi Hauk. Sisteplass læll. 31 poeng. Og 23 av dem på benken.
+Greit nok. Det er alt Reidar har å si om det.
 
-Tjuetre poeng. Van Hecke med 9, Wilson med 8, Dewsbury-Hall med 4, Dúbravka med 2. Alle på benken. Alle ubrukte. Hauk scoret 31 med startelleveren sin og hadde nok poeng på benken til å vinne runden om de hadde spilt. Morgan Rogers som kaptein ga 4 poeng — to base ganger to — i en runde der João Pedro og Haaland lå der for plukking. Det er den typen uke som får folk til å google «hvordan slette FPL-lag». Reidar vet. Han har googlet det selv. Man finner ikke svaret.
+## Bench boost. Fem poeng.
 
-Odas Disipler lander på 37. Summerville som kaptein ga 6, og Stach med sine 11 poeng råtner på benken — det er 11 poeng Oda aldri får tilbake. Oda holder tredjeplassen, men marginene ned til Hedda er tynnere enn de ser ut.
+Torkil. FK Haralds/By.
 
-Hedda og Tafatt IL fikk 41. João Pedro som kaptein var rundens lureste valg — 14 kapteinspoeng, best i ligaen. Men resten av laget motarbeidet henne. Pickford med 1, Mukiele med 1, Stach med 11 på benken etter å ha blitt hentet inn denne uken. Tre bytter, alle med positiv uttelling på papiret, men det hjelper lite når halvparten av startoppstillingen leverer ettall.
+Reidar må ta en pause her. Torkil spilte bench boost — FPLs mest verdifulle chip etter free hit, et våpen man sparer til doble gameweeks og stappfulle runder — i en runde der benken hans leverte tilnærmet ingenting. Wirtz fikk **null**. Alderete fikk 1. Dúbravka og Mané delte 4 poeng mellom seg. Totalt hentet FK Haralds/By omtrent **5 ekstra poeng** fra bench boost.
 
-Camilla spilte wildcard og YVIL scorer 50. Seks bytter inn, João Pedro som kaptein med 14 poeng — samme som Hedda, og samme logikk. James Hill leverte 6 fra forsvaret, og det nye laget ser... vel, det ser ut som et lag. Om det er et *godt* lag gjenstår å se. Wildcard-effekten måles ikke i én runde. Den måles i de neste fem. Camilla klatrer forbi Eirin til sjetteplass, men avstanden er 5 poeng. Det er ingenting.
+Fem.
 
-Eirin og Dragen BK synker til sjuendeplass med 34. Gabriel som kaptein — en forsvarsspiller — ga 4 poeng. Reidar har meninger om å sette kapteinsbåndet på en forsvarsspiller i en runde der Haaland og Palmer er tilgjengelige, men han holder dem for seg selv. Stort sett. Bart Verbruggen på benken med 7 poeng mens Raya startet med 3 er salt i såret. Noen ganger velger man feil keeper. De fleste ganger velger man feil keeper.
+Det er ikke et chiputbytte. Det er en begravelse. Torkil endte på 52, samme som Anders, men med en chip mindre i lomma og ingenting å vise for det. Haaland som kaptein ga **12**, og Muñoz leverte **9**, men det hjelper lite når hensikten med runden var å hente verdi fra en benk som nektet å samarbeide. Reidar har sett bench boost-katastrofer før. Dette er ikke den verste. Men den er oppe og nikker.
 
-Peder og Team Eiden med venna scorer 43 og holder sisteplassen trygt. Van Dijk med 11 og Dunk med 6 bar laget fra forsvarsfireren, mens Ekitiké som kaptein ga 4. Avstanden opp til Eirin er 104 poeng. Det er ikke et gap. Det er en avgrunn. Men Peder har vist før at han kan levere når det gjelder minst. Spørsmålet er om det noen gang gjelder nok.
+## Hauk og benken fra helvete
 
-I sammendraget er det bunnfryst. Ingen byttet plass bortsett fra Camilla og Eirin. Anders leder med 35 poengs margin ned til Torkil, og 271 ned til Peder. Det er fortsatt elleve runder igjen. Reidar sier ikke at det er over. Men han sier heller ikke at det ikke er det.
+**31 poeng**. Og **23 av dem** på benken.
 
-Neste deadline nærmer seg. Torkil har brukt bench boost. Hauk burde vurdere å bruke noe som helst. Og Reidar skal skrive en ny kolonne. Som alltid.
+Van Hecke med 9, Wilson med 8, Dewsbury-Hall med 4, Dúbravka med 2. Alle på benken. Alle ubrukte. Sisteplass læll scoret 31 med startelleveren sin og hadde nok poeng på benken til å *vinne runden* om de hadde spilt. Morgan Rogers som kaptein ga **4 poeng** — i en runde der João Pedro og Haaland lå der for plukking.
+
+Det er den typen uke som får folk til å google «hvordan slette FPL-lag». Reidar vet. Han har googlet det selv. Man finner ikke svaret.
+
+## Resten av feltet
+
+Odas Disipler lander på **37**. Summerville som kaptein ga 6, og Stach med sine **11 poeng** råtner på benken — det er 11 poeng Oda aldri får tilbake. Tredjeplassen holder, men marginene ned til Hedda er tynnere enn de ser ut.
+
+Hedda og Tafatt IL fikk **41**. João Pedro som kaptein var rundens lureste valg — **14 kapteinspoeng**, best i ligaen. Men resten av laget motarbeidet henne. Pickford med 1, Mukiele med 1, Stach med 11 på benken etter å ha blitt hentet inn denne uken. Tre bytter, alle med positiv uttelling på papiret, men det hjelper lite når halvparten av startoppstillingen leverer ettall.
+
+Camilla spilte wildcard og YVIL scorer **50**. Seks bytter inn, João Pedro som kaptein med **14 poeng** — samme som Hedda, og samme logikk. James Hill leverte 6 fra forsvaret, og det nye laget ser... vel, det ser ut som et lag. Om det er et *godt* lag gjenstår å se. Wildcard-effekten måles ikke i én runde. Den måles i de neste fem. Camilla klatrer forbi Eirin til sjetteplass, men avstanden er 5 poeng. Det er ingenting.
+
+Eirin og Dragen BK synker til sjuendeplass med **34**. Gabriel som kaptein — en forsvarsspiller — ga **4 poeng**. Reidar har meninger om å sette kapteinsbåndet på en forsvarsspiller i en runde der Haaland og Palmer er tilgjengelige, men han holder dem for seg selv. Stort sett. Bart Verbruggen på benken med 7 poeng mens Raya startet med 3 er salt i såret.
+
+Peder og Team Eiden med venna scorer **43** og holder sisteplassen trygt. Van Dijk med **11** og Dunk med **6** bar laget fra forsvarsfireren, mens Ekitiké som kaptein ga 4. Avstanden opp til Eirin er **104 poeng**. Det er ikke et gap. Det er en avgrunn.
+
+## Sammendraget
+
+Bunnfryst. Ingen byttet plass bortsett fra Camilla og Eirin. Anders leder med **35 poengs margin** ned til Torkil, og **271** ned til Peder. Elleve runder igjen. Reidar sier ikke at det er over. Men han sier heller ikke at det ikke er det.
+
+Neste deadline nærmer seg. Torkil har brukt bench boost. Hauk burde vurdere å bruke noe som helst. Og Reidar skal skrive en ny kolonne.
+
+Som alltid.

--- a/weekly_report/reports/1638989/2025-26/gw27.json
+++ b/weekly_report/reports/1638989/2025-26/gw27.json
@@ -1,0 +1,1564 @@
+{
+  "meta": {
+    "league_id": "1638989",
+    "league_name": "Sinkaberg administrasjon",
+    "season": "2025-26",
+    "event_id": 27,
+    "generated_at": "2026-02-24T15:45:04.517576+00:00",
+    "previous_report": "weekly_report/reports/1638989/2025-26/gw26.json",
+    "previous_narrative": "weekly_report/narratives/1638989/2025-26/gw26.md"
+  },
+  "standings": [
+    {
+      "entry_id": 4738712,
+      "team_name": "Thisistheyear",
+      "manager_name": "Anders Morken",
+      "player_first_name": "Anders",
+      "event_total": 52,
+      "net_points": 52,
+      "total_points": 1567,
+      "league_rank": 1,
+      "league_rank_previous": 1,
+      "league_rank_change": 0,
+      "overall_rank": 296074,
+      "team_value": 102.8,
+      "bank": 1.0,
+      "bench_points": 15,
+      "bench_players": [
+        {
+          "name": "Martin Dúbravka",
+          "points": 2,
+          "element_id": 470
+        },
+        {
+          "name": "Harry Wilson",
+          "points": 8,
+          "element_id": 329
+        },
+        {
+          "name": "Mateus Mané",
+          "points": 2,
+          "element_id": 749
+        },
+        {
+          "name": "Malick Thiaw",
+          "points": 3,
+          "element_id": 684
+        }
+      ],
+      "chip_played": null,
+      "captain": {
+        "name": "Cole Palmer",
+        "points": 6,
+        "element_id": 235
+      },
+      "vice_captain": {
+        "name": "João Pedro Junqueira de Jesus",
+        "points": 7,
+        "element_id": 249
+      },
+      "squad": [
+        {
+          "element_id": 1,
+          "name": "David Raya Martín",
+          "position": 1,
+          "points": 3,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 5,
+          "name": "Gabriel dos Santos Magalhães",
+          "position": 2,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 8,
+          "name": "Jurriën Timber",
+          "position": 3,
+          "points": 3,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 694,
+          "name": "Nordi Mukiele",
+          "position": 4,
+          "points": 1,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 411,
+          "name": "Nico O'Reilly",
+          "position": 5,
+          "points": 17,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 237,
+          "name": "Enzo Fernández",
+          "position": 6,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 450,
+          "name": "Matheus Santos Carneiro da Cunha",
+          "position": 7,
+          "points": 3,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 303,
+          "name": "James Garner",
+          "position": 8,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 235,
+          "name": "Cole Palmer",
+          "position": 9,
+          "points": 3,
+          "is_captain": true,
+          "multiplier": 2
+        },
+        {
+          "element_id": 430,
+          "name": "Erling Haaland",
+          "position": 10,
+          "points": 6,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 249,
+          "name": "João Pedro Junqueira de Jesus",
+          "position": 11,
+          "points": 7,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 470,
+          "name": "Martin Dúbravka",
+          "position": 12,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 329,
+          "name": "Harry Wilson",
+          "position": 13,
+          "points": 8,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 749,
+          "name": "Mateus Mané",
+          "position": 14,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 684,
+          "name": "Malick Thiaw",
+          "position": 15,
+          "points": 3,
+          "is_captain": false,
+          "multiplier": 0
+        }
+      ],
+      "transfers": [],
+      "transfer_cost": 0,
+      "transfers_made": 0
+    },
+    {
+      "entry_id": 811114,
+      "team_name": "FK Haralds/By",
+      "manager_name": "Torkil Johnsen",
+      "player_first_name": "Torkil",
+      "event_total": 52,
+      "net_points": 52,
+      "total_points": 1532,
+      "league_rank": 2,
+      "league_rank_previous": 2,
+      "league_rank_change": 0,
+      "overall_rank": 719321,
+      "team_value": 105.3,
+      "bank": 2.1,
+      "bench_points": 0,
+      "bench_players": [],
+      "chip_played": "bboost",
+      "captain": {
+        "name": "Erling Haaland",
+        "points": 12,
+        "element_id": 430
+      },
+      "vice_captain": {
+        "name": "Bruno Borges Fernandes",
+        "points": 2,
+        "element_id": 449
+      },
+      "squad": [
+        {
+          "element_id": 670,
+          "name": "Robin Roefs",
+          "position": 1,
+          "points": 1,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 226,
+          "name": "Trevoh Chalobah",
+          "position": 2,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 5,
+          "name": "Gabriel dos Santos Magalhães",
+          "position": 3,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 8,
+          "name": "Jurriën Timber",
+          "position": 4,
+          "points": 3,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 256,
+          "name": "Daniel Muñoz Mejía",
+          "position": 5,
+          "points": 9,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 21,
+          "name": "Declan Rice",
+          "position": 6,
+          "points": 4,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 449,
+          "name": "Bruno Borges Fernandes",
+          "position": 7,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 329,
+          "name": "Harry Wilson",
+          "position": 8,
+          "points": 8,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 237,
+          "name": "Enzo Fernández",
+          "position": 9,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 430,
+          "name": "Erling Haaland",
+          "position": 10,
+          "points": 6,
+          "is_captain": true,
+          "multiplier": 2
+        },
+        {
+          "element_id": 136,
+          "name": "Igor Thiago Nascimento Rodrigues",
+          "position": 11,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 470,
+          "name": "Martin Dúbravka",
+          "position": 12,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 382,
+          "name": "Florian Wirtz",
+          "position": 13,
+          "points": 0,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 683,
+          "name": "Omar Alderete",
+          "position": 14,
+          "points": 1,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 749,
+          "name": "Mateus Mané",
+          "position": 15,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        }
+      ],
+      "transfers": [],
+      "transfer_cost": 0,
+      "transfers_made": 0
+    },
+    {
+      "entry_id": 8811904,
+      "team_name": "Odas Disipler",
+      "manager_name": "Oda Myhre",
+      "player_first_name": "Oda",
+      "event_total": 37,
+      "net_points": 37,
+      "total_points": 1496,
+      "league_rank": 3,
+      "league_rank_previous": 3,
+      "league_rank_change": 0,
+      "overall_rank": 1423236,
+      "team_value": 101.6,
+      "bank": 0.9,
+      "bench_points": 17,
+      "bench_players": [
+        {
+          "name": "Simon Moore",
+          "points": 0,
+          "element_id": 529
+        },
+        {
+          "name": "Marc Guéhi",
+          "points": 2,
+          "element_id": 260
+        },
+        {
+          "name": "Daniel Ballard",
+          "points": 4,
+          "element_id": 531
+        },
+        {
+          "name": "Anton Stach",
+          "points": 11,
+          "element_id": 660
+        }
+      ],
+      "chip_played": null,
+      "captain": {
+        "name": "Crysencio Summerville",
+        "points": 6,
+        "element_id": 615
+      },
+      "vice_captain": {
+        "name": "Erling Haaland",
+        "points": 6,
+        "element_id": 430
+      },
+      "squad": [
+        {
+          "element_id": 1,
+          "name": "David Raya Martín",
+          "position": 1,
+          "points": 3,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 407,
+          "name": "Matheus Nunes",
+          "position": 2,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 5,
+          "name": "Gabriel dos Santos Magalhães",
+          "position": 3,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 575,
+          "name": "Micky van de Ven",
+          "position": 4,
+          "points": 0,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 21,
+          "name": "Declan Rice",
+          "position": 5,
+          "points": 4,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 615,
+          "name": "Crysencio Summerville",
+          "position": 6,
+          "points": 3,
+          "is_captain": true,
+          "multiplier": 2
+        },
+        {
+          "element_id": 449,
+          "name": "Bruno Borges Fernandes",
+          "position": 7,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 329,
+          "name": "Harry Wilson",
+          "position": 8,
+          "points": 8,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 64,
+          "name": "Ollie Watkins",
+          "position": 9,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 430,
+          "name": "Erling Haaland",
+          "position": 10,
+          "points": 6,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 136,
+          "name": "Igor Thiago Nascimento Rodrigues",
+          "position": 11,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 529,
+          "name": "Simon Moore",
+          "position": 12,
+          "points": 0,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 260,
+          "name": "Marc Guéhi",
+          "position": 13,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 531,
+          "name": "Daniel Ballard",
+          "position": 14,
+          "points": 4,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 660,
+          "name": "Anton Stach",
+          "position": 15,
+          "points": 11,
+          "is_captain": false,
+          "multiplier": 0
+        }
+      ],
+      "transfers": [],
+      "transfer_cost": 0,
+      "transfers_made": 0
+    },
+    {
+      "entry_id": 9347056,
+      "team_name": "Tafatt IL",
+      "manager_name": "Hedda Wahl-Ovesen",
+      "player_first_name": "Hedda",
+      "event_total": 41,
+      "net_points": 41,
+      "total_points": 1467,
+      "league_rank": 4,
+      "league_rank_previous": 4,
+      "league_rank_change": 0,
+      "overall_rank": 2186037,
+      "team_value": 102.9,
+      "bank": 0.3,
+      "bench_points": 16,
+      "bench_players": [
+        {
+          "name": "Martin Dúbravka",
+          "points": 2,
+          "element_id": 470
+        },
+        {
+          "name": "Dominic Calvert-Lewin",
+          "points": 2,
+          "element_id": 691
+        },
+        {
+          "name": "James Tarkowski",
+          "points": 1,
+          "element_id": 291
+        },
+        {
+          "name": "Anton Stach",
+          "points": 11,
+          "element_id": 660
+        }
+      ],
+      "chip_played": null,
+      "captain": {
+        "name": "João Pedro Junqueira de Jesus",
+        "points": 14,
+        "element_id": 249
+      },
+      "vice_captain": {
+        "name": "Erling Haaland",
+        "points": 6,
+        "element_id": 430
+      },
+      "squad": [
+        {
+          "element_id": 287,
+          "name": "Jordan Pickford",
+          "position": 1,
+          "points": 1,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 226,
+          "name": "Trevoh Chalobah",
+          "position": 2,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 8,
+          "name": "Jurriën Timber",
+          "position": 3,
+          "points": 3,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 260,
+          "name": "Marc Guéhi",
+          "position": 4,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 694,
+          "name": "Nordi Mukiele",
+          "position": 5,
+          "points": 1,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 237,
+          "name": "Enzo Fernández",
+          "position": 6,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 449,
+          "name": "Bruno Borges Fernandes",
+          "position": 7,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 21,
+          "name": "Declan Rice",
+          "position": 8,
+          "points": 4,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 82,
+          "name": "Antoine Semenyo",
+          "position": 9,
+          "points": 4,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 249,
+          "name": "João Pedro Junqueira de Jesus",
+          "position": 10,
+          "points": 7,
+          "is_captain": true,
+          "multiplier": 2
+        },
+        {
+          "element_id": 430,
+          "name": "Erling Haaland",
+          "position": 11,
+          "points": 6,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 470,
+          "name": "Martin Dúbravka",
+          "position": 12,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 691,
+          "name": "Dominic Calvert-Lewin",
+          "position": 13,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 291,
+          "name": "James Tarkowski",
+          "position": 14,
+          "points": 1,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 660,
+          "name": "Anton Stach",
+          "position": 15,
+          "points": 11,
+          "is_captain": false,
+          "multiplier": 0
+        }
+      ],
+      "transfers": [
+        {
+          "player_in": "João Pedro Junqueira de Jesus",
+          "player_out": "Igor Thiago Nascimento Rodrigues",
+          "player_in_points": 7,
+          "player_out_points": 2
+        },
+        {
+          "player_in": "Anton Stach",
+          "player_out": "Harry Wilson",
+          "player_in_points": 11,
+          "player_out_points": 8
+        },
+        {
+          "player_in": "Marc Guéhi",
+          "player_out": "Maxence Lacroix",
+          "player_in_points": 2,
+          "player_out_points": 0
+        }
+      ],
+      "transfer_cost": 0,
+      "transfers_made": 3
+    },
+    {
+      "entry_id": 7229447,
+      "team_name": "Sisteplass læll",
+      "manager_name": "Hauk Holten",
+      "player_first_name": "Hauk",
+      "event_total": 31,
+      "net_points": 31,
+      "total_points": 1420,
+      "league_rank": 5,
+      "league_rank_previous": 5,
+      "league_rank_change": 0,
+      "overall_rank": 3668265,
+      "team_value": 101.0,
+      "bank": 0.2,
+      "bench_points": 23,
+      "bench_players": [
+        {
+          "name": "Martin Dúbravka",
+          "points": 2,
+          "element_id": 470
+        },
+        {
+          "name": "Jan Paul van Hecke",
+          "points": 9,
+          "element_id": 151
+        },
+        {
+          "name": "Kiernan Dewsbury-Hall",
+          "points": 4,
+          "element_id": 242
+        },
+        {
+          "name": "Harry Wilson",
+          "points": 8,
+          "element_id": 329
+        }
+      ],
+      "chip_played": null,
+      "captain": {
+        "name": "Morgan Rogers",
+        "points": 4,
+        "element_id": 47
+      },
+      "vice_captain": {
+        "name": "Jurriën Timber",
+        "points": 3,
+        "element_id": 8
+      },
+      "squad": [
+        {
+          "element_id": 220,
+          "name": "Robert Lynch Sánchez",
+          "position": 1,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 226,
+          "name": "Trevoh Chalobah",
+          "position": 2,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 72,
+          "name": "Marcos Senesi Barón",
+          "position": 3,
+          "points": 5,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 8,
+          "name": "Jurriën Timber",
+          "position": 4,
+          "points": 3,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 694,
+          "name": "Nordi Mukiele",
+          "position": 5,
+          "points": 1,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 47,
+          "name": "Morgan Rogers",
+          "position": 6,
+          "points": 2,
+          "is_captain": true,
+          "multiplier": 2
+        },
+        {
+          "element_id": 237,
+          "name": "Enzo Fernández",
+          "position": 7,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 449,
+          "name": "Bruno Borges Fernandes",
+          "position": 8,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 661,
+          "name": "Hugo Ekitiké",
+          "position": 9,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 136,
+          "name": "Igor Thiago Nascimento Rodrigues",
+          "position": 10,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 430,
+          "name": "Erling Haaland",
+          "position": 11,
+          "points": 6,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 470,
+          "name": "Martin Dúbravka",
+          "position": 12,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 151,
+          "name": "Jan Paul van Hecke",
+          "position": 13,
+          "points": 9,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 242,
+          "name": "Kiernan Dewsbury-Hall",
+          "position": 14,
+          "points": 4,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 329,
+          "name": "Harry Wilson",
+          "position": 15,
+          "points": 8,
+          "is_captain": false,
+          "multiplier": 0
+        }
+      ],
+      "transfers": [],
+      "transfer_cost": 0,
+      "transfers_made": 0
+    },
+    {
+      "entry_id": 8916452,
+      "team_name": "YVIL",
+      "manager_name": "Camilla Moen",
+      "player_first_name": "Camilla",
+      "event_total": 50,
+      "net_points": 50,
+      "total_points": 1405,
+      "league_rank": 6,
+      "league_rank_previous": 7,
+      "league_rank_change": 1,
+      "overall_rank": 4166658,
+      "team_value": 99.3,
+      "bank": 0.3,
+      "bench_points": 11,
+      "bench_players": [
+        {
+          "name": "Jordan Pickford",
+          "points": 1,
+          "element_id": 287
+        },
+        {
+          "name": "Harry Wilson",
+          "points": 8,
+          "element_id": 329
+        },
+        {
+          "name": "Nordi Mukiele",
+          "points": 1,
+          "element_id": 694
+        },
+        {
+          "name": "Josh Acheampong",
+          "points": 1,
+          "element_id": 233
+        }
+      ],
+      "chip_played": "wildcard",
+      "captain": {
+        "name": "João Pedro Junqueira de Jesus",
+        "points": 14,
+        "element_id": 249
+      },
+      "vice_captain": {
+        "name": "Bruno Borges Fernandes",
+        "points": 2,
+        "element_id": 449
+      },
+      "squad": [
+        {
+          "element_id": 32,
+          "name": "Emiliano Martínez Romero",
+          "position": 1,
+          "points": 3,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 77,
+          "name": "James Hill",
+          "position": 2,
+          "points": 6,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 684,
+          "name": "Malick Thiaw",
+          "position": 3,
+          "points": 3,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 725,
+          "name": "Piero Hincapié",
+          "position": 4,
+          "points": 4,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 449,
+          "name": "Bruno Borges Fernandes",
+          "position": 5,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 237,
+          "name": "Enzo Fernández",
+          "position": 6,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 82,
+          "name": "Antoine Semenyo",
+          "position": 7,
+          "points": 4,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 26,
+          "name": "Martín Zubimendi Ibáñez",
+          "position": 8,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 430,
+          "name": "Erling Haaland",
+          "position": 9,
+          "points": 6,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 624,
+          "name": "Jarrod Bowen",
+          "position": 10,
+          "points": 4,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 249,
+          "name": "João Pedro Junqueira de Jesus",
+          "position": 11,
+          "points": 7,
+          "is_captain": true,
+          "multiplier": 2
+        },
+        {
+          "element_id": 287,
+          "name": "Jordan Pickford",
+          "position": 12,
+          "points": 1,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 329,
+          "name": "Harry Wilson",
+          "position": 13,
+          "points": 8,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 694,
+          "name": "Nordi Mukiele",
+          "position": 14,
+          "points": 1,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 233,
+          "name": "Josh Acheampong",
+          "position": 15,
+          "points": 1,
+          "is_captain": false,
+          "multiplier": 0
+        }
+      ],
+      "transfers": [
+        {
+          "player_in": "Emiliano Martínez Romero",
+          "player_out": "Robert Lynch Sánchez",
+          "player_in_points": 3,
+          "player_out_points": 2
+        },
+        {
+          "player_in": "Josh Acheampong",
+          "player_out": "James Tarkowski",
+          "player_in_points": 1,
+          "player_out_points": 1
+        },
+        {
+          "player_in": "James Hill",
+          "player_out": "Michael Keane",
+          "player_in_points": 6,
+          "player_out_points": 2
+        },
+        {
+          "player_in": "João Pedro Junqueira de Jesus",
+          "player_out": "Dominic Calvert-Lewin",
+          "player_in_points": 7,
+          "player_out_points": 2
+        },
+        {
+          "player_in": "Harry Wilson",
+          "player_out": "Carlos Henrique Casimiro",
+          "player_in_points": 8,
+          "player_out_points": 5
+        },
+        {
+          "player_in": "Antoine Semenyo",
+          "player_out": "Matheus Santos Carneiro da Cunha",
+          "player_in_points": 4,
+          "player_out_points": 3
+        }
+      ],
+      "transfer_cost": 0,
+      "transfers_made": 0
+    },
+    {
+      "entry_id": 7345147,
+      "team_name": "Dragen BK",
+      "manager_name": "Eirin Ottesen",
+      "player_first_name": "Eirin",
+      "event_total": 34,
+      "net_points": 34,
+      "total_points": 1400,
+      "league_rank": 7,
+      "league_rank_previous": 6,
+      "league_rank_change": -1,
+      "overall_rank": 4332193,
+      "team_value": 101.2,
+      "bank": 0.1,
+      "bench_points": 7,
+      "bench_players": [
+        {
+          "name": "Bart Verbruggen",
+          "points": 7,
+          "element_id": 139
+        },
+        {
+          "name": "Bruno Guimarães Rodriguez Moura",
+          "points": 0,
+          "element_id": 488
+        },
+        {
+          "name": "Lewis Miley",
+          "points": 0,
+          "element_id": 497
+        },
+        {
+          "name": "Justin Devenny",
+          "points": 0,
+          "element_id": 276
+        }
+      ],
+      "chip_played": null,
+      "captain": {
+        "name": "Gabriel dos Santos Magalhães",
+        "points": 4,
+        "element_id": 5
+      },
+      "vice_captain": {
+        "name": "Bruno Borges Fernandes",
+        "points": 2,
+        "element_id": 449
+      },
+      "squad": [
+        {
+          "element_id": 1,
+          "name": "David Raya Martín",
+          "position": 1,
+          "points": 3,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 36,
+          "name": "Matty Cash",
+          "position": 2,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 407,
+          "name": "Matheus Nunes",
+          "position": 3,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 226,
+          "name": "Trevoh Chalobah",
+          "position": 4,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 5,
+          "name": "Gabriel dos Santos Magalhães",
+          "position": 5,
+          "points": 2,
+          "is_captain": true,
+          "multiplier": 2
+        },
+        {
+          "element_id": 683,
+          "name": "Omar Alderete",
+          "position": 6,
+          "points": 1,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 235,
+          "name": "Cole Palmer",
+          "position": 7,
+          "points": 3,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 449,
+          "name": "Bruno Borges Fernandes",
+          "position": 8,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 430,
+          "name": "Erling Haaland",
+          "position": 9,
+          "points": 6,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 100,
+          "name": "Junior Kroupi",
+          "position": 10,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 249,
+          "name": "João Pedro Junqueira de Jesus",
+          "position": 11,
+          "points": 7,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 139,
+          "name": "Bart Verbruggen",
+          "position": 12,
+          "points": 7,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 488,
+          "name": "Bruno Guimarães Rodriguez Moura",
+          "position": 13,
+          "points": 0,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 497,
+          "name": "Lewis Miley",
+          "position": 14,
+          "points": 0,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 276,
+          "name": "Justin Devenny",
+          "position": 15,
+          "points": 0,
+          "is_captain": false,
+          "multiplier": 0
+        }
+      ],
+      "transfers": [],
+      "transfer_cost": 0,
+      "transfers_made": 0
+    },
+    {
+      "entry_id": 9258220,
+      "team_name": "Team Eiden med venna",
+      "manager_name": "Peder Eiden",
+      "player_first_name": "Peder",
+      "event_total": 43,
+      "net_points": 43,
+      "total_points": 1296,
+      "league_rank": 8,
+      "league_rank_previous": 8,
+      "league_rank_change": 0,
+      "overall_rank": 7458850,
+      "team_value": 98.1,
+      "bank": 0.1,
+      "bench_points": 3,
+      "bench_players": [
+        {
+          "name": "Martin Dúbravka",
+          "points": 2,
+          "element_id": 470
+        },
+        {
+          "name": "Tijjani Reijnders",
+          "points": 0,
+          "element_id": 427
+        },
+        {
+          "name": "Marc Cucurella Saseta",
+          "points": 0,
+          "element_id": 224
+        },
+        {
+          "name": "Gabriel Gudmundsson",
+          "points": 1,
+          "element_id": 347
+        }
+      ],
+      "chip_played": null,
+      "captain": {
+        "name": "Hugo Ekitiké",
+        "points": 4,
+        "element_id": 661
+      },
+      "vice_captain": {
+        "name": "Ollie Watkins",
+        "points": 2,
+        "element_id": 64
+      },
+      "squad": [
+        {
+          "element_id": 736,
+          "name": "Gianluigi Donnarumma",
+          "position": 1,
+          "points": 5,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 373,
+          "name": "Virgil van Dijk",
+          "position": 2,
+          "points": 11,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 191,
+          "name": "Maxime Estève",
+          "position": 3,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 146,
+          "name": "Lewis Dunk",
+          "position": 4,
+          "points": 6,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 47,
+          "name": "Morgan Rogers",
+          "position": 5,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 417,
+          "name": "Rayan Cherki",
+          "position": 6,
+          "points": 1,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 16,
+          "name": "Bukayo Saka",
+          "position": 7,
+          "points": 5,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 235,
+          "name": "Cole Palmer",
+          "position": 8,
+          "points": 3,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 661,
+          "name": "Hugo Ekitiké",
+          "position": 9,
+          "points": 2,
+          "is_captain": true,
+          "multiplier": 2
+        },
+        {
+          "element_id": 64,
+          "name": "Ollie Watkins",
+          "position": 10,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 136,
+          "name": "Igor Thiago Nascimento Rodrigues",
+          "position": 11,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 1
+        },
+        {
+          "element_id": 470,
+          "name": "Martin Dúbravka",
+          "position": 12,
+          "points": 2,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 427,
+          "name": "Tijjani Reijnders",
+          "position": 13,
+          "points": 0,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 224,
+          "name": "Marc Cucurella Saseta",
+          "position": 14,
+          "points": 0,
+          "is_captain": false,
+          "multiplier": 0
+        },
+        {
+          "element_id": 347,
+          "name": "Gabriel Gudmundsson",
+          "position": 15,
+          "points": 1,
+          "is_captain": false,
+          "multiplier": 0
+        }
+      ],
+      "transfers": [],
+      "transfer_cost": 0,
+      "transfers_made": 0
+    }
+  ],
+  "awards": {
+    "highest_scorer": {
+      "player_name": "Anders",
+      "points": 52,
+      "team_name": "Thisistheyear"
+    },
+    "lowest_scorer": {
+      "player_name": "Hauk",
+      "points": 31,
+      "team_name": "Sisteplass læll"
+    },
+    "biggest_rise": null,
+    "biggest_fall": null,
+    "bench_disasters": [
+      {
+        "player_name": "Hauk",
+        "bench_points": 23,
+        "event_total": 31
+      }
+    ],
+    "best_transfer": {
+      "player_name": "Camilla",
+      "net_gain": 14,
+      "transfers": [
+        {
+          "player_in": "Emiliano Martínez Romero",
+          "player_out": "Robert Lynch Sánchez",
+          "player_in_points": 3,
+          "player_out_points": 2
+        },
+        {
+          "player_in": "Josh Acheampong",
+          "player_out": "James Tarkowski",
+          "player_in_points": 1,
+          "player_out_points": 1
+        },
+        {
+          "player_in": "James Hill",
+          "player_out": "Michael Keane",
+          "player_in_points": 6,
+          "player_out_points": 2
+        },
+        {
+          "player_in": "João Pedro Junqueira de Jesus",
+          "player_out": "Dominic Calvert-Lewin",
+          "player_in_points": 7,
+          "player_out_points": 2
+        },
+        {
+          "player_in": "Harry Wilson",
+          "player_out": "Carlos Henrique Casimiro",
+          "player_in_points": 8,
+          "player_out_points": 5
+        },
+        {
+          "player_in": "Antoine Semenyo",
+          "player_out": "Matheus Santos Carneiro da Cunha",
+          "player_in_points": 4,
+          "player_out_points": 3
+        }
+      ]
+    },
+    "worst_transfer": {
+      "player_name": "Hedda",
+      "net_loss": 10,
+      "transfers": [
+        {
+          "player_in": "João Pedro Junqueira de Jesus",
+          "player_out": "Igor Thiago Nascimento Rodrigues",
+          "player_in_points": 7,
+          "player_out_points": 2
+        },
+        {
+          "player_in": "Anton Stach",
+          "player_out": "Harry Wilson",
+          "player_in_points": 11,
+          "player_out_points": 8
+        },
+        {
+          "player_in": "Marc Guéhi",
+          "player_out": "Maxence Lacroix",
+          "player_in_points": 2,
+          "player_out_points": 0
+        }
+      ]
+    },
+    "captain_summary": {
+      "most_popular": {
+        "player": "João Pedro Junqueira de Jesus",
+        "count": 2
+      },
+      "best_pick": {
+        "manager": "Hedda",
+        "captain": "João Pedro Junqueira de Jesus",
+        "points": 14
+      },
+      "worst_pick": {
+        "manager": "Hauk",
+        "captain": "Morgan Rogers",
+        "points": 4
+      }
+    },
+    "chip_usage": [
+      {
+        "player_name": "Torkil",
+        "chip": "bboost",
+        "points": 52
+      },
+      {
+        "player_name": "Camilla",
+        "chip": "wildcard",
+        "points": 50
+      }
+    ],
+    "hit_takers": []
+  },
+  "league_summary": {
+    "average_score": 42.5,
+    "leader": {
+      "player_name": "Anders",
+      "total_points": 1567
+    },
+    "total_participants": 8
+  }
+}


### PR DESCRIPTION
Reports should be committed — they're historical data used by the narrative system and useful for reference.