### PR TITLE
chore: disable hourly schedule for off-season

### DIFF
--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -1,8 +1,10 @@
 name: Hourly Dashboard & Weekly Report
 
 on:
-  schedule:
-    - cron: "0 * * * *"  # Hourly check
+  # Hourly schedule disabled for the off-season (FPL season over).
+  # To re-activate: uncomment the two lines below.
+  # schedule:
+  #   - cron: "0 * * * *"  # Hourly check
   workflow_dispatch:      # Manual runs skip the check and run everything
 
 permissions:


### PR DESCRIPTION
The FPL season is over, so the **Hourly Dashboard & Weekly Report** workflow no longer needs to run on its hourly cron.

## Change
- Comment out the `schedule:`/`cron` block in `.github/workflows/scheduled-build.yml`.
- Keep `workflow_dispatch` so the workflow can still be run manually from the Actions tab.

## Re-activating next season
Uncomment the two lines under `on:`:

```yaml
  schedule:
    - cron: "0 * * * *"  # Hourly check
```